### PR TITLE
feat/productimage : Implement methods for retrieving all images by product and retrieving the thumbnail (representative) image

### DIFF
--- a/src/main/java/org/example/lastcall/domain/product/controller/ProductImageController.java
+++ b/src/main/java/org/example/lastcall/domain/product/controller/ProductImageController.java
@@ -2,13 +2,9 @@ package org.example.lastcall.domain.product.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.lastcall.common.response.ApiResponse;
-import org.example.lastcall.common.response.PageResponse;
 import org.example.lastcall.domain.product.dto.request.ProductImageCreateRequest;
-import org.example.lastcall.domain.product.dto.response.ProductImageReadAllResponse;
 import org.example.lastcall.domain.product.dto.response.ProductImageResponse;
-import org.example.lastcall.domain.product.entity.ImageType;
 import org.example.lastcall.domain.product.sevice.ProductImageService;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,15 +27,14 @@ public class ProductImageController {
         );
     }
 
-    //이미지 전체 조회(상품아이디와 썸네일만 "/api/v1/products/image?imageType=Thumbnail")
-    @GetMapping("/image")
-    public ResponseEntity<ApiResponse<PageResponse<ProductImageReadAllResponse>>> readThumbnailImages(@RequestParam ImageType imageType,
-                                                                                                      Pageable pageable) {
-        PageResponse<ProductImageReadAllResponse> pageResponse = productImageService.readAllThumbnailImage(imageType, pageable.getPageNumber(), pageable.getPageSize());
-        ApiResponse<PageResponse<ProductImageReadAllResponse>> apiResponse = ApiResponse.success("대표 이미지 전체 조회 성공했습니다.", pageResponse);
-
-        return ResponseEntity.ok(apiResponse);
-    }
+    //이미지 전체 조회 -> 리팩토링 때 삭제 예정
+//    @GetMapping("/image")
+//    public ResponseEntity<ApiResponse<PageResponse<ProductImageReadAllResponse>>> readThumbnailImages(Pageable pageable) {
+//        PageResponse<ProductImageReadAllResponse> pageResponse = productImageService.readAllThumbnailImage(pageable.getPageNumber(), pageable.getPageSize());
+//        ApiResponse<PageResponse<ProductImageReadAllResponse>> apiResponse = ApiResponse.success("대표 이미지 전체 조회 성공했습니다.", pageResponse);
+//
+//        return ResponseEntity.ok(apiResponse);
+//    }
 
     //상품별 이미지 전체 조회
     @GetMapping("/{productId}/image")

--- a/src/main/java/org/example/lastcall/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/org/example/lastcall/domain/product/exception/ProductErrorCode.java
@@ -14,7 +14,8 @@ public enum ProductErrorCode implements ErrorCode {
     TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "사진은 최대 10장 첨부할 수 있습니다."),
     MULTIPLE_THUMBNAILS_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "대표 이미지는 1장만 등록 가능합니다."),
     DUPLICATE_IMAGE_URL_IN_REQUEST(HttpStatus.BAD_REQUEST, "중복 이미지입니다."),
-    DUPLICATE_IMAGE_URL_IN_PRODUCT(HttpStatus.BAD_REQUEST, "한 상품 안에 중복 이미지는 들어갈 수 없습니다.");
+    DUPLICATE_IMAGE_URL_IN_PRODUCT(HttpStatus.BAD_REQUEST, "한 상품 안에 중복 이미지는 들어갈 수 없습니다."),
+    THUMBNAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 이미지가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/example/lastcall/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/org/example/lastcall/domain/product/repository/ProductImageRepository.java
@@ -2,8 +2,6 @@ package org.example.lastcall.domain.product.repository;
 
 import org.example.lastcall.domain.product.entity.ImageType;
 import org.example.lastcall.domain.product.entity.ProductImage;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,8 +9,6 @@ import java.util.Optional;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
     List<ProductImage> findAllByProductId(Long productId);
-
-    Page<ProductImage> findAllByImageType(ImageType imageType, Pageable pageable);
 
     Optional<ProductImage> findByProductIdAndImageType(Long productId, ImageType imageType);
 

--- a/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageService.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageService.java
@@ -2,17 +2,13 @@ package org.example.lastcall.domain.product.sevice;
 
 import lombok.RequiredArgsConstructor;
 import org.example.lastcall.common.exception.BusinessException;
-import org.example.lastcall.common.response.PageResponse;
 import org.example.lastcall.domain.product.dto.request.ProductImageCreateRequest;
-import org.example.lastcall.domain.product.dto.response.ProductImageReadAllResponse;
 import org.example.lastcall.domain.product.dto.response.ProductImageResponse;
 import org.example.lastcall.domain.product.entity.ImageType;
 import org.example.lastcall.domain.product.entity.Product;
 import org.example.lastcall.domain.product.entity.ProductImage;
 import org.example.lastcall.domain.product.exception.ProductErrorCode;
 import org.example.lastcall.domain.product.repository.ProductImageRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,14 +50,17 @@ public class ProductImageService implements ProductImageServiceApi {
                 .toList();
     }
 
-    //이미지 전체 조회(상품아이디와 썸네일만 "/api/v1/products/image?imageType=Thumbnail")
+    //대표이미지 조회
+    @Override
     @Transactional(readOnly = true)
-    public PageResponse<ProductImageReadAllResponse> readAllThumbnailImage(ImageType imageType, int page, int size) {
-        Page<ProductImage> productImages = productImageRepository.findAllByImageType(imageType, PageRequest.of(page, size));
-        return ProductImageReadAllResponse.from(productImages);
+    public ProductImageResponse readThumbnailImage(Long productId) {
+        ProductImage thumbnailImage = productImageRepository.findByProductIdAndImageType(productId, ImageType.THUMBNAIL)
+                .orElseThrow(() -> new BusinessException(ProductErrorCode.THUMBNAIL_NOT_FOUND));
+        return ProductImageResponse.from(thumbnailImage);
     }
 
     //상품별 이미지 전체 조회
+    @Override
     @Transactional(readOnly = true)
     public List<ProductImageResponse> readAllProductImage(Long productId) {
         List<ProductImage> productImages = productImageRepository.findAllByProductId(productId);

--- a/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageServiceApi.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageServiceApi.java
@@ -1,4 +1,13 @@
 package org.example.lastcall.domain.product.sevice;
 
+import org.example.lastcall.domain.product.dto.response.ProductImageResponse;
+
+import java.util.List;
+
 public interface ProductImageServiceApi {
+    // 대표 이미지(썸네일) 조회
+    ProductImageResponse readThumbnailImage(Long productId);
+
+    // 상품별 이미지리스트 조회
+    List<ProductImageResponse> readAllProductImage(Long productId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #65 


## 📝작업 내용(이미지 첨부 가능)
- 상품의 대표 이미지 조회 메서드 구현
- 상품의 이미지 전체 조회 메서드 구현


## ✅ 테스트 방법

## 📎 기타 참고 사항
모든 경매의 대표 이미지들을 전체 조회하는 로직에서 대표 이미지 단건 조회로 바뀌었습니다. (경매 전체조회에서 대표 이미지를 join해서 조회할 예정) 따라서 **대표 이미지 전체 조회 API는 삭제 예정입니다!** 

## 💬리뷰 요구사항(선택)
