### PR TITLE
feat/bid: Implement method to verify user's bid existence on auction

### DIFF
--- a/src/main/java/org/example/lastcall/domain/bid/repository/BidRepository.java
+++ b/src/main/java/org/example/lastcall/domain/bid/repository/BidRepository.java
@@ -17,4 +17,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	@EntityGraph(attributePaths = {"user"})
 	Page<Bid> findAllByAuction(Auction auction, Pageable pageable);
+
+	boolean existsByAuctionIdAndUserId(Long auctionId, Long userId);
 }

--- a/src/main/java/org/example/lastcall/domain/bid/service/BidService.java
+++ b/src/main/java/org/example/lastcall/domain/bid/service/BidService.java
@@ -61,4 +61,12 @@ public class BidService implements BidServiceApi {
 
 		return PageResponse.of(bidPage.map(BidGetAllResponse::from));
 	}
+
+	@Override
+	public boolean existsByAuctionIdAndUserId(Long auctionId, Long userId) {
+		// if (auctionId == null || userId == null) {
+		// 	throw new BusinessException(BidErrorCode.INVALID_BID_CHECK_REQUEST);
+		// }
+		return bidRepository.existsByAuctionIdAndUserId(auctionId, userId);
+	}
 }

--- a/src/main/java/org/example/lastcall/domain/bid/service/BidServiceApi.java
+++ b/src/main/java/org/example/lastcall/domain/bid/service/BidServiceApi.java
@@ -1,4 +1,6 @@
 package org.example.lastcall.domain.bid.service;
 
 public interface BidServiceApi {
+	// 특정 경매에 해당 사용자의 입찰 존재 여부 확인
+	boolean existsByAuctionIdAndUserId(Long auctionId, Long userId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #60 
- Related #이슈번호


## 📝작업 내용(이미지 첨부 가능)
- BidServiceApi에 특정 경매(auctionId)와 사용자(userId)의 입찰 존재 여부를 boolean으로 반환하는 existsByAuctionIdAndUserId 메서드 시그니처를 추가했습니다.
- BidService (구현체)에 위 메서드를 @Override 하여 구현했습니다.
- BidRepository.existsByAuctionIdAndUserId를 호출하여 실제 DB 존재 여부를 반환합니다.
- BidRepository 인터페이스에 existsByAuctionIdAndUserId(Long auctionId, Long userId) 메서드를 선언하여, Spring Data JPA가 쿼리를 자동 생성하도록 설정했습니다.
- 이 기능은 추후 경매 단건 조회 시, 현재 사용자의 입찰 참여 여부를 확인하는 데 사용됩니다.


## ✅ 테스트 방법


## 📎 기타 참고 사항


## 💬리뷰 요구사항(선택)
