### PR TITLE
refactor/bid: Remove BaseEntity inheritance

### DIFF
--- a/src/main/java/org/example/lastcall/domain/bid/entity/Bid.java
+++ b/src/main/java/org/example/lastcall/domain/bid/entity/Bid.java
@@ -1,11 +1,15 @@
 package org.example.lastcall.domain.bid.entity;
 
-import org.example.lastcall.common.entity.BaseEntity;
+import java.time.LocalDateTime;
+
 import org.example.lastcall.domain.auction.entity.Auction;
 import org.example.lastcall.domain.user.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,14 +24,19 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "bids")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)    // 외부에서 new Bid() 하는 것을 막기 위함
-public class Bid extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;    // 입찰 ID
+public class Bid {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;    // 입찰 ID
 
 	@Column(name = "bid_amount", nullable = false)
 	private Long bidAmount;    // 입찰가
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;    // 생성일
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "auction_id", nullable = false)


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #92 
- Related #이슈번호


## 📝작업 내용(이미지 첨부 가능)
- Bid 엔티티의 구조를 개선하기 위해 BaseEntity 상속 관계를 제거했습니다.


## ✅ 테스트 방법


## 📎 기타 참고 사항



## 💬리뷰 요구사항(선택)
