### PR TITLE
feat/bid: Implement getCurrentBidAmount method

### DIFF
--- a/src/main/java/org/example/lastcall/domain/bid/service/BidService.java
+++ b/src/main/java/org/example/lastcall/domain/bid/service/BidService.java
@@ -75,4 +75,11 @@ public class BidService implements BidServiceApi {
 		// }
 		return bidRepository.existsByAuctionIdAndUserId(auctionId, userId);
 	}
+
+	@Override
+	public Long getCurrentBidAmount(Long auctionId) {
+		Auction auction = auctionServiceApi.findById(auctionId);
+
+		return bidRepository.findMaxBidAmountByAuction(auction).orElse(auction.getStartingBid());
+	}
 }

--- a/src/main/java/org/example/lastcall/domain/bid/service/BidServiceApi.java
+++ b/src/main/java/org/example/lastcall/domain/bid/service/BidServiceApi.java
@@ -3,4 +3,7 @@ package org.example.lastcall.domain.bid.service;
 public interface BidServiceApi {
 	// 특정 경매에 해당 사용자의 입찰 존재 여부 확인
 	boolean existsByAuctionIdAndUserId(Long auctionId, Long userId);
+
+	// 특정 경매의 최고 입찰가 조회
+	Long getCurrentBidAmount(Long auctionId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #94 
- Related #이슈번호


## 📝작업 내용(이미지 첨부 가능)
- BidService에 getCurrentBidAmount(Long auctionId) 메서드를 추가했습니다.
- 이 메서드는 BidRepository를 사용하여 특정 경매의 최고 입찰가를 조회합니다.
- 만약 해당 경매에 입찰 내역이 하나도 없다면, 경매 시작가를 현재가로 반환하도록 구현했습니다.


## ✅ 테스트 방법


## 📎 기타 참고 사항


## 💬리뷰 요구사항(선택)

