### PR TITLE
feat/product: Implement functionality to add additional images when updating a product

### DIFF
--- a/src/main/java/org/example/lastcall/domain/product/controller/ProductImageController.java
+++ b/src/main/java/org/example/lastcall/domain/product/controller/ProductImageController.java
@@ -29,6 +29,16 @@ public class ProductImageController {
         );
     }
 
+    //상품 수정 시 이미지 추가 기능
+    @PostMapping("/{productId}/images/append")
+    public ResponseEntity<ApiResponse<List<ProductImageResponse>>> appendProductImages(@PathVariable Long productId,
+                                                                                       @RequestBody List<ProductImageCreateRequest> requests) {
+        List<ProductImageResponse> response = productCommandServiceApi.appendImagesToProduct(productId, requests);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("상품 이미지를 추가등록했습니다.", response));
+    }
+
     //상품 대표 이미지 변경 업데이트
     @PatchMapping("/{productId}/image/{imageId}")
     public ResponseEntity<ApiResponse<List<ProductImageResponse>>> updateThumbnailImage(@PathVariable Long productId,

--- a/src/main/java/org/example/lastcall/domain/product/entity/ProductImage.java
+++ b/src/main/java/org/example/lastcall/domain/product/entity/ProductImage.java
@@ -10,12 +10,7 @@ import org.example.lastcall.common.entity.BaseEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(
-        name = "product_image",
-        //한 상품 당 하나의 이미지만 THUMBNAIL이 될 수 있도록 제약
-        uniqueConstraints = @UniqueConstraint(
-                columnNames = {"product_id", "image_type"}
-        ))
+@Table(name = "product_image")
 public class ProductImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/lastcall/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/org/example/lastcall/domain/product/exception/ProductErrorCode.java
@@ -15,7 +15,8 @@ public enum ProductErrorCode implements ErrorCode {
     DUPLICATE_IMAGE_URL_IN_REQUEST(HttpStatus.BAD_REQUEST, "중복 이미지입니다."),
     DUPLICATE_IMAGE_URL_IN_PRODUCT(HttpStatus.BAD_REQUEST, "한 상품 안에 중복 이미지는 들어갈 수 없습니다."),
     THUMBNAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 이미지가 존재하지 않습니다."),
-    IMAGE_NOT_BELONGS_TO_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품에 속한 이미지가 아닙니다.");
+    IMAGE_NOT_BELONGS_TO_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품에 속한 이미지가 아닙니다."),
+    MAX_IMAGE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지는 최대 10장입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/example/lastcall/domain/product/sevice/ProductCommandService.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/ProductCommandService.java
@@ -64,4 +64,11 @@ public class ProductCommandService implements ProductCommandServiceApi {
         //ProductImageService에 Product 엔티티를 인자로 전달하여 호출 (단방향)
         return productImageCommandServiceApi.createProductImages(product, requests);
     }
+
+    @Override
+    public List<ProductImageResponse> appendImagesToProduct(Long productId, List<ProductImageCreateRequest> requests) {
+        Product product = productRepository.findById(productId).orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        return productImageCommandServiceApi.appendProductImages(product, requests);
+    }
 }

--- a/src/main/java/org/example/lastcall/domain/product/sevice/ProductCommandServiceApi.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/ProductCommandServiceApi.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface ProductCommandServiceApi {
     List<ProductImageResponse> addImagesToProduct(Long productId, List<ProductImageCreateRequest> requests);
+
+    List<ProductImageResponse> appendImagesToProduct(Long productId, List<ProductImageCreateRequest> requests);
 }

--- a/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageServiceApi.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/ProductImageServiceApi.java
@@ -10,4 +10,6 @@ public interface ProductImageServiceApi {
     void softDeleteByProductId(Long productId);
 
     List<ProductImageResponse> createProductImages(Product product, List<ProductImageCreateRequest> requests);
+
+    List<ProductImageResponse> appendProductImages(Product product, List<ProductImageCreateRequest> requests);
 }


### PR DESCRIPTION


## #️⃣연관된 이슈
- Close #118


## 📝작업 내용(이미지 첨부 가능)
- 상품 수정 시 이미지 추가 기능 구현


## ✅ 테스트 방법
1. [X] 서버 실행 (`./gradlew bootRun`)(예시1)
2. [X] `POST /api/v1/products/{productId}/images/append` 호출 시 정상적으로 응답되는지 확인
<img width="860" height="729" alt="스크린샷 2025-10-23 오전 11 27 34" src="https://github.com/user-attachments/assets/6ad5fead-4f7d-4790-8303-92dbcacdcdc7" />


## 📎 기타 참고 사항

## 💬리뷰 요구사항(선택)
