### PR TITLE
fix/user: resolve syntax error

### DIFF
--- a/src/main/java/org/example/lastcall/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/org/example/lastcall/domain/user/exception/UserErrorCode.java
@@ -21,7 +21,6 @@ public enum UserErrorCode implements ErrorCode {
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "이전 비밀번호와 동일합니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "새 비밀번호와 확인 비밀번호가 일치하지 않습니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "이전 비밀번호와 동일합니다.");
-    NO_FIELDS_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 항목이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #52


## 📝작업 내용(이미지 첨부 가능)
- 잘못된 세미콜론으로 인해 빌드가 실패하던 문제 수정


## ✅ 테스트 방법
1. [ ] 서버 실행 (`./gradlew bootRun`)(예시1)
2. [ ] 관련 API 호출 시 빌드 및 런타임 에러가 발생하지 않는지 확인


## 📎 기타 참고 사항
- 단순 문법 오류 수정으로 로직 변경 없음


## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
