### PR TITLE
fix/validate: add DB existing thumbnail validation in product image creation

### DIFF
--- a/src/main/java/org/example/lastcall/domain/product/sevice/command/ProductCommandService.java
+++ b/src/main/java/org/example/lastcall/domain/product/sevice/command/ProductCommandService.java
@@ -70,7 +70,7 @@ public class ProductCommandService implements ProductCommandServiceApi {
                 })
                 .toList();
 
-        productValidator.ensureSingleThumbnail(images);
+        productValidator.validateThumbnailConsistency(productId, images);
 
         List<ProductImage> savedImages = productImageRepository.saveAll(images);
 
@@ -133,7 +133,7 @@ public class ProductCommandService implements ProductCommandServiceApi {
         }
 
         //썸네일 한 개만 유지
-        productValidator.ensureSingleThumbnail(allImages);
+        productValidator.validateThumbnailConsistency(productId, allImages);
 
         //중복 URL 체크
         productValidator.validateDuplicateUrlsForAll(allImages);


### PR DESCRIPTION

## #️⃣연관된 이슈
- Close #216 


## 📝작업 내용(이미지 첨부 가능)
- 이미지 등록시 DB를 조회해 해당 상품에 썸네일이 이미 존재할 경우 예외처리


## ✅ 테스트 방법
1. [X] 서버 실행 (`./gradlew bootRun`)(예시1)


## 📎 기타 참고 사항


## 💬리뷰 요구사항(선택)
