### PR TITLE
fix/product: fix thumbnail validation logic when appending product images

### DIFF
--- a/src/main/java/org/example/lastcall/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/org/example/lastcall/domain/product/service/command/ProductCommandService.java
@@ -70,7 +70,7 @@ public class ProductCommandService implements ProductCommandServiceApi {
                 })
                 .toList();
 
-        productValidator.validateThumbnailConsistency(productId, images);
+        productValidator.validateThumbnailConsistencyForCreate(productId, images);
 
         List<ProductImage> savedImages = productImageRepository.saveAll(images);
 
@@ -133,7 +133,7 @@ public class ProductCommandService implements ProductCommandServiceApi {
         }
 
         //썸네일 한 개만 유지
-        productValidator.validateThumbnailConsistency(productId, allImages);
+        productValidator.validateThumbnailConsistencyForAppend(allImages);
 
         //중복 URL 체크
         productValidator.validateDuplicateUrlsForAll(allImages);


### PR DESCRIPTION

## #️⃣연관된 이슈
- Close #240 


## 📝작업 내용(이미지 첨부 가능)
  public void validateThumbnailConsistencyForAppend(List<ProductImage> allImages) {
    long thumbnailCount = allImages.stream()
            .filter(img -> img.getImageType() == ImageType.THUMBNAIL)
            .count();

    log.info("[VALIDATE] thumbnailCount={}, imageTypes={}",
            thumbnailCount, allImages.stream().map(ProductImage::getImageType).toList());

    if (thumbnailCount > 1) {
        throw new BusinessException(ProductErrorCode.MULTIPLE_THUMBNAILS_NOT_ALLOWED);
    }
}

## ✅ 테스트 방법
1. [X] 서버 실행 (`./gradlew bootRun`)(예시1)


## 📎 기타 참고 사항


## 💬리뷰 요구사항(선택)
<img width="892" height="833" alt="스크린샷 2025-11-04 오전 11 40 31" src="https://github.com/user-attachments/assets/7a2faffc-4405-4253-bebf-61328212ddd1" />

