### PR TITLE
Test/user: add unit tests for user domain services

### DIFF
--- a/src/test/java/org/example/lastcall/domain/user/UserCommandServiceTest.java
+++ b/src/test/java/org/example/lastcall/domain/user/UserCommandServiceTest.java
@@ -1,0 +1,206 @@
+package org.example.lastcall.domain.user;
+
+import org.example.lastcall.common.config.PasswordEncoder;
+import org.example.lastcall.common.exception.BusinessException;
+import org.example.lastcall.domain.auth.repository.RefreshTokenRepository;
+import org.example.lastcall.domain.user.dto.request.PasswordChangeRequest;
+import org.example.lastcall.domain.user.dto.request.UserUpdateRequest;
+import org.example.lastcall.domain.user.dto.response.UserProfileResponse;
+import org.example.lastcall.domain.user.entity.User;
+import org.example.lastcall.domain.user.enums.Role;
+import org.example.lastcall.domain.user.exception.UserErrorCode;
+import org.example.lastcall.domain.user.repository.UserRepository;
+import org.example.lastcall.domain.user.service.command.UserCommandService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+        import static org.mockito.BDDMockito.*;
+        import static org.example.lastcall.domain.auth.enums.RefreshTokenStatus.*;
+
+class UserCommandServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private UserCommandService userCommandService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testUser = User.createForSignUp(
+                UUID.randomUUID(),
+                "tester",
+                "nick",
+                "test@email.com",
+                "encodedPw",
+                "Seoul",
+                "12345",
+                "Suwon",
+                "010-1234-5678",
+                Role.USER
+        );
+    }
+
+    // updateMyProfile() 테스트
+    @Test
+    @DisplayName("내 정보 수정 성공")
+    void updateMyProfile_success() {
+        // given
+        Long userId = 1L;
+        UserUpdateRequest req = new UserUpdateRequest("newNick", "010-7777-8888", null);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userRepository.existsByNickname("newNick")).willReturn(false);
+
+        // when
+        UserProfileResponse res = userCommandService.updateMyProfile(userId, req);
+
+        // then
+        assertThat(res.nickname()).isEqualTo("newNick");
+        assertThat(testUser.getPhoneNumber()).isEqualTo("010-7777-8888");
+        then(userRepository).should(times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 수정 시 예외 발생")
+    void updateMyProfile_userNotFound() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.updateMyProfile(1L, mock(UserUpdateRequest.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 사용자 수정 시 예외 발생")
+    void updateMyProfile_deletedUser() {
+        // given
+        testUser.softDelete();
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.updateMyProfile(1L, mock(UserUpdateRequest.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 시 예외 발생")
+    void updateMyProfile_duplicateNickname() {
+        // given
+        Long userId = 1L;
+        UserUpdateRequest req = new UserUpdateRequest("dupNick", null, null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userRepository.existsByNickname("dupNick")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.updateMyProfile(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.DUPLICATE_NICKNAME.getMessage());
+    }
+
+    // changeMyPassword() 테스트
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void changeMyPassword_success() {
+        // given
+        Long userId = 1L;
+        PasswordChangeRequest req = new PasswordChangeRequest("oldPw", "newPw");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches("oldPw", testUser.getPassword())).willReturn(true);
+        given(passwordEncoder.matches("newPw", testUser.getPassword())).willReturn(false);
+        given(passwordEncoder.encode("newPw")).willReturn("encodedNewPw");
+
+        // when
+        userCommandService.changeMyPassword(userId, req);
+
+        // then
+        assertThat(testUser.getPassword()).isEqualTo("encodedNewPw");
+        then(refreshTokenRepository).should(times(1))
+                .revokeAllActiveByUserId(testUser.getId(), ACTIVE, REVOKED);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 기존과 동일할 경우 예외 발생")
+    void changeMyPassword_samePassword() {
+        // given
+        Long userId = 1L;
+        PasswordChangeRequest req = new PasswordChangeRequest("oldPw", "newPw");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches("oldPw", testUser.getPassword())).willReturn(true);
+        given(passwordEncoder.matches("newPw", testUser.getPassword())).willReturn(true); // 같은 비밀번호
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.changeMyPassword(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.SAME_AS_OLD_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("기존 비밀번호가 일치하지 않으면 예외 발생")
+    void changeMyPassword_invalidOldPassword() {
+        // given
+        Long userId = 1L;
+        PasswordChangeRequest req = new PasswordChangeRequest("wrongOld", "newPw");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches("wrongOld", testUser.getPassword())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.changeMyPassword(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("삭제된 사용자가 비밀번호 변경 시 예외 발생")
+    void changeMyPassword_deletedUser() {
+        // given
+        testUser.softDelete();
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.changeMyPassword(1L, mock(PasswordChangeRequest.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 비밀번호 변경 시 예외 발생")
+    void changeMyPassword_userNotFound() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                userCommandService.changeMyPassword(1L, mock(PasswordChangeRequest.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/org/example/lastcall/domain/user/UserQueryServiceTest.java
+++ b/src/test/java/org/example/lastcall/domain/user/UserQueryServiceTest.java
@@ -1,0 +1,130 @@
+package org.example.lastcall.domain.user;
+
+import jakarta.persistence.EntityManager;
+import org.example.lastcall.common.exception.BusinessException;
+import org.example.lastcall.domain.user.dto.response.UserProfileResponse;
+import org.example.lastcall.domain.user.entity.User;
+import org.example.lastcall.domain.user.enums.Role;
+import org.example.lastcall.domain.user.exception.UserErrorCode;
+import org.example.lastcall.domain.user.repository.UserRepository;
+import org.example.lastcall.domain.user.service.query.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+class UserQueryServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private UserQueryService userQueryService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testUser = User.createForSignUp(
+                UUID.randomUUID(),
+                "tester",
+                "nick",
+                "test@email.com",
+                "encodedPw",
+                "Seoul",
+                "12345",
+                "Gangnam",
+                "010-1234-5678",
+                Role.USER
+        );
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 성공")
+    void getMyProfile_success() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        // when
+        UserProfileResponse response = userQueryService.getMyProfile(1L);
+
+        // then
+        assertThat(response.nickname()).isEqualTo("nick");
+        assertThat(response.email()).isEqualTo("test@email.com");
+        assertThat(response.phoneNumber()).isEqualTo("010-1234-5678");
+        then(userRepository).should(times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 조회 시 예외 발생")
+    void getMyProfile_userNotFound() {
+        // given
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userQueryService.getMyProfile(999L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 회원 조회 시 예외 발생")
+    void getMyProfile_deletedUser() {
+        // given
+        testUser.softDelete();
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> userQueryService.getMyProfile(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("findById 성공")
+    void findById_success() {
+        // given
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        // when
+        User found = userQueryService.findById(1L);
+
+        // then
+        assertThat(found).isEqualTo(testUser);
+    }
+
+    @Test
+    @DisplayName("findById 실패 - 유저 없음")
+    void findById_notFound() {
+        // given
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userQueryService.findById(2L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("getReferenceById - EntityManager 프록시 반환")
+    void getReferenceById_success() {
+        // given
+        given(entityManager.getReference(User.class, 1L)).willReturn(testUser);
+        User ref = userQueryService.getReferenceById(1L);
+
+        // when & then
+        assertThat(ref).isEqualTo(testUser);
+        then(entityManager).should(times(1)).getReference(User.class, 1L);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #281

## 📝작업 내용(이미지 첨부 가능)
<img width="507" height="238" alt="스크린샷 2025-11-11 오후 10 13 34" src="https://github.com/user-attachments/assets/d7a28b69-29c5-4f92-ab67-865e66a2dd72" /><br>
<img width="507" height="240" alt="스크린샷 2025-11-11 오후 10 13 43" src="https://github.com/user-attachments/assets/9f448e8d-e301-46fb-8c6c-b4784be852e6" /><br>
- UserCommandServiceTest, UserQueryServiceTest 작성


## ✅ 테스트 방법
1. [ ] ./gradlew test 실행
2. [ ] IntelliJ → JaCoCo 리포트 확인 (domain.user 라인 커버리지 30% 이상)
3. [ ] 다음 항목이 정상적으로 통과되는지 확인
      - UserQueryServiceTest 내 findById_success() 테스트 통과
      - UserCommandServiceTest 내 updateMyProfile_success() 테스트 통과
      - 예외 발생 시 BusinessException 정상 throw
      - 테스트 커버리지 향상 확인 (user 도메인 약 60%)

## 📎 기타 참고 사항
- 리뷰어가 알아야 할 추가 맥락이나 참고 자료를 적어주세요.


## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
