### PR TITLE
feat/server: add Spring Boot config for RabbitMQ and Redis

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,7 +32,15 @@ spring:
         enable: true
       connectiontimeout: 5s  # 연결 타임아웃 (5초)
       timeout: 5s           # 읽기 타임아웃 (5초)
-      writetimeout: 5s      # 쓰기 타임아웃 (5초)
+      writetimeout: 5s  # 쓰기 타임아웃 (5초)
+  rabbitmq:
+    host: rabbitmq-dev
+    port: 5672
+    username: guest
+    password: guest
+  redis:
+    redis:
+      url: redis://redis-dev:6379
 
 springdoc:
   api-docs.enabled: true


### PR DESCRIPTION
## #️⃣연관된 이슈
- Close #299 

## 📝작업 내용(이미지 첨부 가능)
- application-dev.yml에 RabbitMQ host, port, username, password 추가
- Redis 설정을 Spring Boot 3.x 권장 방식인 URI(spring.redis.url)로 변경
- Docker 컨테이너 이름(rabbitmq-dev, redis-dev) 기반 연결 설정 반영


## ✅ 테스트 방법
- [ ]  Docker에서 Redis(redis-dev)와 RabbitMQ(rabbitmq-dev) 컨테이너 실행
- [ ] Spring Boot 앱 실행 (./gradlew bootRun)
- [ ] 앱 로그에서 RabbitMQ, Redis 연결 성공 메시지 확인
- [ ] 관련 API 호출 시 Redis 캐싱 및 메시지 큐 정상 동작 확인


## 📎 기타 참고 사항
- Redis와 RabbitMQ 컨테이너는 같은 Docker 네트워크에 연결되어 있어야 함
- Spring Boot 3.x 환경에서 Redis는 URI 방식 사용 권장

## 💬리뷰 요구사항(선택)
- spring.redis.url 사용 방식이 적절한지 확인 부탁드립니다
- RabbitMQ 연결 설정 구조(spring.rabbitmq vs rabbitmq)에 대한 의견 환영