### PR TITLE
chore/ci: Restore test execution in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           RABBITMQ_PORT: 5672
           RABBITMQ_USERNAME: guest
           RABBITMQ_PASSWORD: guest
-        run: ./gradlew clean build -x test --no-daemon
+        run: ./gradlew clean build --no-daemon
 
       - name: Upload problems report
         if: always()


### PR DESCRIPTION

## #️⃣연관된 이슈
(없음)

## 📝 작업 내용
- `.github/workflows/ci.yml` 파일에서 `-x test` 옵션이 남아 있어 테스트가 스킵되는 문제를 수정
- run: `./gradlew clean build -x test --no-daemon` → `./gradlew clean build --no-daemon` 로 변경하여 CI 테스트가 정상적으로 실행되도록 복구
- 어제 잠시 옵션을 빼두셨던 설정이 남아 있었던 것으로 확인되어 해당 부분을 원복함

## ✅ 테스트 방법
1. [ ] PR 머지 후 새로운 PR 생성하여 CI 파이프라인 실행
2. [ ] CI에서 테스트가 정상적으로 실행되는지 확인 (`BUILD SUCCESSFUL` 및 test task 실행 로그 확인)
3. [ ] 테스트 실패 시 CI가 실패로 뜨는지 확인

## 📎 기타 참고 사항
- CI 파이프라인에서 테스트 스킵 상태가 계속 유지되면 팀 전체 안정성에 영향을 줄 수 있어 빠르게 복구한 PR입니다.

## 💬 리뷰 요구사항(선택)
- 특별한 부분은 없으며, 변경된 옵션이 정상적으로 동작하는지만 확인해주시면 됩니다!