### PR TITLE
feat/infra: add /healthz endpoint for ALB health check

### DIFF
--- a/src/main/java/org/example/lastcall/common/monitoring/HealthCheckController.java
+++ b/src/main/java/org/example/lastcall/common/monitoring/HealthCheckController.java
@@ -1,0 +1,13 @@
+package org.example.lastcall.common.monitoring;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+    @GetMapping("/healthz")
+    public ResponseEntity<String> healthz() {
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/org/example/lastcall/common/security/SecurityConfig.java
+++ b/src/main/java/org/example/lastcall/common/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/v1/email-verifications/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/healthz").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #328

---

## 📝 작업 내용
- ALB가 `/actuator/health` 호출 시 CustomHealthIndicator 때문에 DB count 쿼리를 반복 실행하던 문제 해결
- 헬스체크 전용 `HealthCheckController` 추가
  - GET `/healthz` → 단순 "OK" 반환
- Spring Security 설정 수정하여 `/healthz` 접근 허용
- ALB Target Group의 Health Check Path를 `/healthz` 로 변경 예정
- 기존 `/actuator/health` 는 유지되므로 모니터링 기능에는 영향 없음
----

## 📝 변경된 코드 (요약)
- `common.monitoring.HealthCheckController` 생성
- SecurityConfig에 `/healthz` permitAll 추가

---

## ✅ 테스트 방법
1. [X] 애플리케이션 실행 후 `/healthz` 호출 시 `"OK"` 응답 확인
<img width="724" height="449" alt="스크린샷 2025-11-16 오후 12 33 02" src="https://github.com/user-attachments/assets/b9ad7aed-70bb-4321-b687-6ecd869d1e18" />


2. [X] Security 적용 상태에서 인증 없이 `/healthz` 접근 가능한지 확인
3. [x] ALB Health Check Path를 `/healthz` 로 변경 후 Target Group이 Healthy 상태인지 확인
4. [x] 서버 로그에서 더 이상 `select count(*) from users` 쿼리가 반복 출력되지 않는지 확인

---

## 📎 기타 참고 사항
- 기존 `/actuator/health` 는 모니터링 팀에서 활용 가능하도록 그대로 유지합니다.
- CustomHealthIndicator는 삭제하지 않으며, ALB 헬스체크만 `/healthz` 로 분리합니다.

---

## 💬 리뷰 요구사항 (선택)
- `/healthz` 컨트롤러 위치(common.monitoring)가 적절한지 검토 부탁드립니다.
- SecurityConfig 내 permitAll 처리 위치도 함께 확인해주시면 감사하겠습니다.