### PR TITLE
fix application-dev.yml enable-statistics true

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -48,6 +48,7 @@ spring:
     redis:
       time-to-live: 3600s
       cache-null-values: false
+      enable-statistics: true
     cache-names: userPoints
 
 springdoc:


### PR DESCRIPTION
제목 예시: application-dev.yml 에서 cache.enable-statistics 를 true 로 설정

## #️⃣연관된 이슈
- Close #이슈번호
- Related #이슈번호


## 📝작업 내용(이미지 첨부 가능)
- 변경된 기능/코드 설명을 작성해주세요.
- 필요하다면 스크린샷이나 다이어그램을 첨부해주세요.


## ✅ 테스트 방법
1. [ ] 서버 실행 (`./gradlew bootRun`)(예시1)
2. [ ] `POST /api/v1/users` 호출 시 정상적으로 신규 유저가 생성되는지 확인(예시2)
3. [ ] `GET /api/v1/users/{id}` 호출 시 방금 생성한 유저 정보가 반환되는지 확인(예시3)
4. [ ] 잘못된 요청(`id=-1`) 시 400 에러가 반환되는지 확인(예시4)


## 📎 기타 참고 사항
- 리뷰어가 알아야 할 추가 맥락이나 참고 자료를 적어주세요.


## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
